### PR TITLE
Update misleading exception message

### DIFF
--- a/src/Reflection.php
+++ b/src/Reflection.php
@@ -78,7 +78,7 @@ class Reflection
         }
 
         if ($argv && !is_array($argv)) {
-            throw new Reflection\Exception\InvalidArgumentException('Invalid argv argument passed to reflectClass');
+            throw new Reflection\Exception\InvalidArgumentException('Invalid argv argument passed to reflectFunction');
         }
 
         return new ReflectionFunction(new \ReflectionFunction($function), $namespace, $argv);


### PR DESCRIPTION
I updated misleading exception message that made me believe I called other method than I in fact did call.
