### PR TITLE
Preparing for 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,4 +20,5 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- [#2](https://github.com/zendframework/zend-server/pull/2) fixes misleading exception in reflectFunction that referenced reflectClass.
+- [#2](https://github.com/zendframework/zend-server/pull/2) fixes misleading
+  exception in reflectFunction that referenced reflectClass.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "zendframework/zend-stdlib": "~2.5",
         "zendframework/zend-code": "~2.5"
     },
@@ -21,8 +21,8 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "2.5-dev",
-            "dev-develop": "2.6-dev"
+            "dev-master": "2.6-dev",
+            "dev-develop": "2.7-dev"
         }
     },
     "autoload-dev": {
@@ -31,7 +31,7 @@
         }
     },
     "require-dev": {
-        "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
+        "fabpot/php-cs-fixer": "^1.7.0",
+        "phpunit/PHPUnit": "^4.0"
     }
 }


### PR DESCRIPTION
Merges develop to master in preparation for 2.6.0, and does the following:
- Updates the PHP version to `^5.5 || ^7.0`
- Updates the version requirements for phpunit and php-cs-fixer
- Sets new branch aliases
