### PR TITLE
Allowed to use callable as callback function

### DIFF
--- a/src/Method/Callback.php
+++ b/src/Method/Callback.php
@@ -103,7 +103,7 @@ class Callback
      */
     public function setFunction($function)
     {
-        $this->function = (string) $function;
+        $this->function = is_callable($function) ? $function : (string) $function;
         $this->setType('function');
         return $this;
     }

--- a/src/Method/Callback.php
+++ b/src/Method/Callback.php
@@ -22,7 +22,7 @@ class Callback
     protected $class;
 
     /**
-     * @var string Function name for function callback
+     * @var string|callable Function name or callable for function callback
      */
     protected $function;
 
@@ -98,7 +98,7 @@ class Callback
     /**
      * Set callback function
      *
-     * @param  string $function
+     * @param  string|callable $function
      * @return \Zend\Server\Method\Callback
      */
     public function setFunction($function)
@@ -111,7 +111,7 @@ class Callback
     /**
      * Get callback function
      *
-     * @return null|string
+     * @return null|string|callable
      */
     public function getFunction()
     {
@@ -144,7 +144,7 @@ class Callback
      * Set callback type
      *
      * @param  string $type
-     * @return Callback
+     * @return \Zend\Server\Method\Callback
      * @throws Server\Exception\InvalidArgumentException
      */
     public function setType($type)

--- a/test/Method/CallbackTest.php
+++ b/test/Method/CallbackTest.php
@@ -75,6 +75,13 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $this->callback->getFunction());
     }
 
+    public function testFunctionMayBeCallable()
+    {
+        $callable = function () {};
+        $this->callback->setFunction($callable);
+        $this->assertEquals($callable, $this->callback->getFunction());
+    }
+
     public function testTypeShouldBeNullByDefault()
     {
         $this->assertNull($this->callback->getType());

--- a/test/Method/CallbackTest.php
+++ b/test/Method/CallbackTest.php
@@ -19,6 +19,11 @@ use Zend\Server\Method;
 class CallbackTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var Method\Callback
+     */
+    private $callback;
+
+    /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      *
@@ -27,16 +32,6 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->callback = new Method\Callback();
-    }
-
-    /**
-     * Tears down the fixture, for example, close a network connection.
-     * This method is called after a test is executed.
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
     }
 
     public function testClassShouldBeNullByDefault()
@@ -77,7 +72,9 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
 
     public function testFunctionMayBeCallable()
     {
-        $callable = function () {};
+        $callable = function () {
+            return true;
+        };
         $this->callback->setFunction($callable);
         $this->assertEquals($callable, $this->callback->getFunction());
     }


### PR DESCRIPTION
Callable may be very useful as function of Callback. For example, for lazy initialization of complicated handler via service container.