### PR TITLE
Handling $skipMethods list when $methods is an array in Cache::save

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -51,6 +51,12 @@ class Cache
                 $definition->addMethod($method);
             }
             $methods = $definition;
+        } elseif (is_array($methods)) {
+            foreach (array_keys($methods) as $methodName) {
+                if (in_array($methodName, static::$skipMethods)) {
+                    unset($methods[$methodName]);
+                }
+            }
         }
 
         ErrorHandler::start();


### PR DESCRIPTION
$server->getFunctions() returns an array. But in Cache::save $methods list filtered only when $methods instance of Definition (never?).
Added $methods cleaning when $methods is an array.