### PR TITLE
Fix (un)serialization for Reflection* objects - PHP 7.4

### DIFF
--- a/src/Reflection/AbstractFunction.php
+++ b/src/Reflection/AbstractFunction.php
@@ -81,11 +81,11 @@ abstract class AbstractFunction
      */
     protected $docComment = '';
 
-    private $return;
-    private $returnDesc;
-    private $paramDesc;
-    private $sigParams;
-    private $sigParamsDepth;
+    protected $return;
+    protected $returnDesc;
+    protected $paramDesc;
+    protected $sigParams;
+    protected $sigParamsDepth;
 
     /**
      * Constructor

--- a/src/Reflection/AbstractFunction.php
+++ b/src/Reflection/AbstractFunction.php
@@ -52,6 +52,12 @@ abstract class AbstractFunction
     protected $class;
 
     /**
+     * Function name (needed for serialization)
+     * @var string
+     */
+    protected $name;
+
+    /**
      * Function/method description
      * @var string
      */
@@ -108,6 +114,8 @@ abstract class AbstractFunction
         if ($r instanceof PhpReflectionMethod) {
             $this->class = $r->getDeclaringClass()->getName();
         }
+
+        $this->name = $r->getName();
 
         // Perform some introspection
         $this->reflect();
@@ -439,6 +447,25 @@ abstract class AbstractFunction
     }
 
     /**
+     * @return string[]
+     */
+    public function __sleep()
+    {
+        $serializable = [];
+        foreach ($this as $name => $value) {
+            if ($value instanceof PhpReflectionFunction
+                || $value instanceof PhpReflectionMethod
+            ) {
+                continue;
+            }
+
+            $serializable[] = $name;
+        }
+
+        return $serializable;
+    }
+
+    /**
      * Wakeup from serialization
      *
      * Reflection needs explicit instantiation to work correctly. Re-instantiate
@@ -450,9 +477,9 @@ abstract class AbstractFunction
     {
         if ($this->reflection instanceof PhpReflectionMethod) {
             $class = new PhpReflectionClass($this->class);
-            $this->reflection = new PhpReflectionMethod($class->newInstance(), $this->getName());
+            $this->reflection = new PhpReflectionMethod($class->newInstance(), $this->name);
         } else {
-            $this->reflection = new PhpReflectionFunction($this->getName());
+            $this->reflection = new PhpReflectionFunction($this->name);
         }
     }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -43,6 +43,12 @@ class ReflectionClass
     protected $reflection;
 
     /**
+     * Reflection class name (needed for serialization)
+     * @var string
+     */
+    protected $name;
+
+    /**
      * Constructor
      *
      * Create array of dispatchable methods, each a
@@ -55,6 +61,7 @@ class ReflectionClass
     public function __construct(PhpReflectionClass $reflection, $namespace = null, $argv = false)
     {
         $this->reflection = $reflection;
+        $this->name = $reflection->getName();
         $this->setNamespace($namespace);
 
         foreach ($reflection->getMethods() as $method) {
@@ -171,6 +178,14 @@ class ReflectionClass
      */
     public function __wakeup()
     {
-        $this->reflection = new PhpReflectionClass($this->getName());
+        $this->reflection = new PhpReflectionClass($this->name);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function __sleep()
+    {
+        return ['config', 'methods', 'namespace', 'name'];
     }
 }

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -58,6 +58,7 @@ class ReflectionMethod extends AbstractFunction
 
         // If method call, need to store some info on the class
         $this->class = $class->getName();
+        $this->name = $r->getName();
 
         // Perform some introspection
         $this->reflect();
@@ -88,7 +89,7 @@ class ReflectionMethod extends AbstractFunction
             $this->getNamespace(),
             $this->getInvokeArguments()
         );
-        $this->reflection = new \ReflectionMethod($this->classReflection->getName(), $this->getName());
+        $this->reflection = new \ReflectionMethod($this->classReflection->getName(), $this->name);
     }
 
     /**

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -38,6 +38,18 @@ class ReflectionParameter
     protected $description;
 
     /**
+     * Parameter name (needed for serialization)
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Declaring function name (needed for serialization)
+     * @var string
+     */
+    protected $functionName;
+
+    /**
      * Constructor
      *
      * @param \ReflectionParameter $r
@@ -47,6 +59,13 @@ class ReflectionParameter
     public function __construct(\ReflectionParameter $r, $type = 'mixed', $description = '')
     {
         $this->reflection = $r;
+
+        // Store parameters needed for (un)serialization
+        $this->name = $r->getName();
+        $this->functionName = $r->getDeclaringClass()
+            ? [$r->getDeclaringClass()->getName(), $r->getDeclaringFunction()->getName()]
+            : $r->getDeclaringFunction()->getName();
+
         $this->setType($type);
         $this->setDescription($description);
     }
@@ -139,5 +158,18 @@ class ReflectionParameter
     public function getPosition()
     {
         return $this->position;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function __sleep()
+    {
+        return ['position', 'type', 'description', 'name', 'functionName'];
+    }
+
+    public function __wakeup()
+    {
+        $this->reflection = new \ReflectionParameter($this->functionName, $this->name);
     }
 }


### PR DESCRIPTION
Fixes #29

>   . Reflection objects will now generate an exception if an attempt is made
    to serialize them. Serialization for reflection objects was never
    supported and resulted in corrupted reflection objects. It has been
    explicitly prohibited now.

https://github.com/php/php-src/blob/php-7.4.0RC3/UPGRADING

Now in our objects we are storing internally declaring names (class name/function name/parameter name) so we can create reflection object on wakeup. Reflection object is not serialized, just the names. 

/cc @remicollet 
